### PR TITLE
Update README: reflect abstract state view rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ angular.module('myApp', [
       .state('admin', {
         url: '/admin',
         abstract: true,
+        template: '<ui-view/>',
         resolve: {
           auth: function($auth) {
             return $auth.validateUser();


### PR DESCRIPTION
Submitting this change in hopes it might prevent someone else going mad when their views templates don't load. (Especially those that might copy/paste...)

As per the rule on abstract state views: "Abstract states still need their own <ui-view/> for their children to plug into. So if you are using an abstract state just to prepend a url, set resolves/data, or run an onEnter/Exit function, then you'll additionally need to set template: '<ui-view/>'"
