### PR TITLE
Change bundle install to bower install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,7 +1068,7 @@ There is a test project in the `test` directory of this app. To start a dev serv
 
 1. `cd` to the root of this project.
 1. `npm install`
-1. `cd test && bundle install`
+1. `cd test && bower install`
 1. `cd ..`
 1. `gulp dev`
 


### PR DESCRIPTION
Is this supposed to be `bower install`? There's no Gemfile for bundler to read in the test directory (or in the whole project).
