### PR TITLE
Fix typo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ This method broadcasts the following events:
 angular.module('ngTokenAuthTestApp')
   .controller('IndexCtrl', function($auth) {
     $scope.handlePwdResetBtnClick = function() {
-      $auth.resetPasswordReset($scope.pwdResetForm)
+      $auth.requestPasswordReset($scope.pwdResetForm)
         .then(function(resp) { 
           // handle success response
         })


### PR DESCRIPTION
There was a typo in the controller example on the 4th line for [$auth.requestPasswordReset](http://github.com/lynndylanhurley/ng-token-auth#authrequestpasswordreset). '$auth.resetPasswordReset' should be '$auth.requestPasswordReset'.
