### PR TITLE
fix(error-handling): ensure authHeaders are updated on error responses if token headers are provided

### DIFF
--- a/dist/ng-token-auth.js
+++ b/dist/ng-token-auth.js
@@ -606,10 +606,8 @@ angular.module('ng-token-auth', ['ngCookies']).provider('$auth', function() {
           responseError: function(resp) {
             $injector.invoke([
               '$http', '$auth', function($http, $auth) {
-                var shouldReject;
                 if (resp.config.url.match($auth.apiUrl())) {
-                  updateHeadersFromResponse($auth, resp);
-                  return shouldReject = true;
+                  return updateHeadersFromResponse($auth, resp);
                 }
               }
             ]);

--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -685,7 +685,6 @@ angular.module('ng-token-auth', ['ngCookies'])
         $injector.invoke ['$http', '$auth', ($http, $auth) ->
           if resp.config.url.match($auth.apiUrl())
             updateHeadersFromResponse($auth, resp)
-            shouldReject = true
         ]
 
         return $injector.get('$q').reject(resp)


### PR DESCRIPTION
I had originally opened this issue under devise_token_auth (see also: https://github.com/lynndylanhurley/devise_token_auth/issues/46), but this seems like something that should happen regardless of if the server chooses to update tokens during error responses.
