### PR TITLE
set path to cookies

### DIFF
--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -82,12 +82,12 @@ angular.module('ng-token-auth', ['ngCookies'])
         '$http'
         '$q'
         '$location'
-        '$cookieStore'
+        'ipCookie'
         '$window'
         '$timeout'
         '$rootScope'
         '$interpolate'
-        ($http, $q, $location, $cookieStore, $window, $timeout, $rootScope, $interpolate) =>
+        ($http, $q, $location, ipCookie, $window, $timeout, $rootScope, $interpolate) =>
           header:            null
           dfd:               null
           user:              {}
@@ -546,7 +546,7 @@ angular.module('ng-token-auth', ['ngCookies'])
             switch @getConfig(configName).storage
               when 'localStorage'
                 $window.localStorage.setItem(key, JSON.stringify(val))
-              else $cookieStore.put(key, val)
+              else ipCookie(key, val, { path: '/' })
 
 
           # abstract persistent data retrieval
@@ -554,7 +554,7 @@ angular.module('ng-token-auth', ['ngCookies'])
             switch @getConfig().storage
               when 'localStorage'
                 JSON.parse($window.localStorage.getItem(key))
-              else $cookieStore.get(key)
+              else ipCookie(key)
 
 
           # abstract persistent data removal
@@ -562,7 +562,7 @@ angular.module('ng-token-auth', ['ngCookies'])
             switch @getConfig().storage
               when 'localStorage'
                 $window.localStorage.removeItem(key)
-              else $cookieStore.remove(key)
+              else ipCookie.remove(key)
 
 
           # persist authentication token, client id, uid
@@ -636,7 +636,7 @@ angular.module('ng-token-auth', ['ngCookies'])
             if $window.localStorage
               c ?= JSON.parse($window.localStorage.getItem(key))
 
-            c ?= $cookieStore.get(key)
+            c ?= ipCookie(key)
 
             c ?= defaultConfigName
 


### PR DESCRIPTION
#55 After a long search, I finally found why I always got logged out when trying to access a restricted page.

It look like that `$cookieStore` is setting the cookie according to the path. So I get duplicated `auth_headers`, and the browser for some reason keep the old one.

![screen shot 2014-10-30 at 14 24 30](https://cloud.githubusercontent.com/assets/4422555/4846435/d592e4c6-604b-11e4-84cd-d9baaa688ec1.png)

So I tried to set a path to the cookies, but unfortunately in the [cookieStore documentation](https://docs.angularjs.org/api/ngCookies/service/$cookieStore) it's not possible, at least not yet.

So I have made some research to find an alternative way to do this. And find out this [thread](https://github.com/angular/angular.js/issues/1786). 

So to resolve that issue I used that module:

https://github.com/ivpusic/angular-cookie

By replacing :

``` javascript
$cookieStore.put(key, val)
```

with:

``` javascript
ipCookie(key, val, { path: '/' })
```

And now everything works great, I'm not able to reproduce that issue anymore.
