### PR TITLE
fix(update-user): update header values if corresponding keys are received on update response

### DIFF
--- a/dist/ng-token-auth.js
+++ b/dist/ng-token-auth.js
@@ -222,7 +222,21 @@ angular.module('ng-token-auth', ['ipCookie']).provider('$auth', function() {
             updateAccount: function(params) {
               return $http.put(this.apiUrl() + this.getConfig().accountUpdatePath, params).success((function(_this) {
                 return function(resp) {
-                  angular.extend(_this.user, _this.getConfig().handleAccountUpdateResponse(resp));
+                  var curHeaders, key, newHeaders, updateResponse, val, _ref;
+                  updateResponse = _this.getConfig().handleAccountUpdateResponse(resp);
+                  curHeaders = _this.retrieveData('auth_headers');
+                  angular.extend(_this.user, updateResponse);
+                  if (curHeaders) {
+                    newHeaders = {};
+                    _ref = _this.getConfig().tokenFormat;
+                    for (key in _ref) {
+                      val = _ref[key];
+                      if (curHeaders[key] && updateResponse[key]) {
+                        newHeaders[key] = updateResponse[key];
+                      }
+                    }
+                    _this.setAuthHeaders(newHeaders);
+                  }
                   return $rootScope.$broadcast('auth:account-update-success', resp);
                 };
               })(this)).error(function(resp) {

--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -244,7 +244,21 @@ angular.module('ng-token-auth', ['ipCookie'])
           updateAccount: (params) ->
             $http.put(@apiUrl() + @getConfig().accountUpdatePath, params)
               .success((resp) =>
-                angular.extend @user, @getConfig().handleAccountUpdateResponse(resp)
+
+                updateResponse = @getConfig().handleAccountUpdateResponse(resp)
+                curHeaders = @retrieveData('auth_headers')
+
+                angular.extend @user, updateResponse
+
+                # ensure any critical headers (uid + ?) that are returned in
+                # the update response are updated appropriately in storage
+                if curHeaders
+                  newHeaders = {}
+                  for key, val of @getConfig().tokenFormat
+                    if curHeaders[key] && updateResponse[key]
+                      newHeaders[key] = updateResponse[key]
+                  @setAuthHeaders(newHeaders)
+
                 $rootScope.$broadcast('auth:account-update-success', resp)
               )
               .error((resp) ->

--- a/test/test/unit/ng-token-auth/account-update.coffee
+++ b/test/test/unit/ng-token-auth/account-update.coffee
@@ -1,15 +1,19 @@
 suite 'account update', ->
   dfd = null
   suite 'successful update', ->
-    updatedUser = angular.copy(validUser, {operating_thetan: 123})
+    updatedUser = angular.extend(validUser, {operating_thetan: 123, uid: 'updated_uid'})
     successResp =
       success: true
       data: updatedUser
 
     setup ->
+
       $httpBackend
         .expectPUT('/api/auth')
         .respond(201, successResp)
+
+      sinon.stub($auth, 'retrieveData').returns({uid: validUser.uid})
+      sinon.spy($auth, 'setAuthHeaders')
 
       dfd = $auth.updateAccount({
         operating_thetan: 123
@@ -22,6 +26,9 @@ suite 'account update', ->
 
     test 'user object is updated', ->
       assert.deepEqual($rootScope.user, updatedUser)
+
+    test 'auth_headers is updated with new uid', ->
+      assert $auth.setAuthHeaders.calledWith({uid: 'updated_uid'})
 
     test 'promise is resolved', ->
       resolved = false


### PR DESCRIPTION
See also: https://github.com/lynndylanhurley/devise_token_auth/pull/71

If we receive any response values that mirror the keys we expect in `tokenFormat`, (ie - uid) this updates the corresponding headers accordingly.

Let me know what you think @lynndylanhurley!
