### PR TITLE
Fix expiry to be UTC-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,7 @@ The `tokenFormat` param accepts an object as an argument. Each param of the obje
 * **clientId**: the id of the current device
 
 The `parseExpiry` param accepts a method that will be used to parse the expiration date from the auth headers. The current valid headers will be provided as an argument.
+The method must return the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
 
 ### Using alternate response formats
 

--- a/dist/ng-token-auth.js
+++ b/dist/ng-token-auth.js
@@ -432,7 +432,7 @@ angular.module('ng-token-auth', ['ipCookie']).provider('$auth', function() {
             tokenHasExpired: function() {
               var expiry, now;
               expiry = this.getExpiry();
-              now = new Date().getTime();
+              now = Date.now();
               return expiry && expiry < now;
             },
             getExpiry: function() {
@@ -527,7 +527,7 @@ angular.module('ng-token-auth', ['ipCookie']).provider('$auth', function() {
               newHeaders = angular.extend(this.retrieveData('auth_headers') || {}, h);
               result = this.persistData('auth_headers', newHeaders);
               expiry = this.getExpiry();
-              now = new Date().getTime();
+              now = Date.now();
               if (expiry > now) {
                 if (this.timer != null) {
                   $timeout.cancel(this.timer);


### PR DESCRIPTION
The default configuration make it feel that the parseExpiry function should return the nb of millis since the epoch, but the time is compared to the local time in various places. Fixed that and updated the docs to reflect the change. References :
 * [Date constructor doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)
 * [Date.now() doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now)