### PR TITLE
docs(README): add Successfully installed sass-3.4.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,6 +1286,7 @@ There is a test project in the `test` directory of this app. To start a dev serv
 1. `npm install`
 1. `cd test && bower install`
 1. `cd ..`
+1. `gem install sass`
 1. `gulp dev`
 
 A dev server will start on [localhost:7777](http://localhost:7777).


### PR DESCRIPTION
Parsing documentation for sass-3.4.14
Installing ri documentation for sass-3.4.14
Done installing documentation for sass after 5 seconds
1 gem installed step to devserver setup instructions

I hit the following error when running `gulp dev`. installing the sass gem fixed it, so just adding that to the readme:

	[14:51:41] [gulp-ruby-sass] Error: spawn ENOENT

	events.js:72
	        throw er; // Unhandled 'error' event
	              ^
	Error: spawn ENOENT
	    at errnoException (child_process.js:1000:11)
	    at Process.ChildProcess._handle.onexit (child_process.js:791:34)