### PR TITLE
parseLocation: array loop - conflict with custom polyfill functions

### DIFF
--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -445,8 +445,6 @@ angular.module('ng-token-auth', ['ipCookie'])
             obj = {}
             if locationSubstring
               pairs = locationSubstring.split('&')
-              pair = undefined
-              i = undefined
               for i in pairs
                 if i == ''
                   continue

--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -447,11 +447,10 @@ angular.module('ng-token-auth', ['ipCookie'])
               pairs = locationSubstring.split('&')
               pair = undefined
               i = undefined
-              for i of pairs
-                `i = i`
-                if pairs[i] == ''
+              for i in pairs
+                if i == ''
                   continue
-                pair = pairs[i].split('=')
+                pair = i.split('=')
                 obj[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1])
             obj
 


### PR DESCRIPTION
 I have some problems due to the fact that I add some polyfill functions to the `Array` prototype. Due to that, your implementation iterates over these functions because you use the syntax to iterate over the keys and values in an object.

I propose another (simpler) implementation but if I change the logic, I can go back to the previous implementation and just add a condition in the `continue` condition:
```
if pairs[i] == '' || typeof pairs[i] is 'function'
  continue
```

What do you think?