### PR TITLE
retrieve data from back-end api for submitLogin

### DIFF
--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -221,6 +221,7 @@ angular.module('ng-token-auth', ['ipCookie'])
                 @rejectDfd({
                   reason: 'unauthorized'
                   errors: ['Invalid credentials']
+                  data: resp
                 })
                 $rootScope.$broadcast('auth:login-error', resp)
               )


### PR DESCRIPTION
If we need to retrieve a specific response from the back-end give the possibility to get it via the `data`key of your response

 fix #165 