### PR TITLE
bower dependencies - compatible with Angular 1.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": ">=1.4 <=1.5",
+    "angular": ">=1.4 <=1.5.0",
     "angular-cookie": "~4.0.10"
   }
 }


### PR DESCRIPTION
You need to add a `.0` to `1.5` to bower in order to allow angular 1.5.0