### PR TITLE
submitLogin can have more arguments, to pass to $http.post

### DIFF
--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -212,9 +212,9 @@ angular.module('ng-token-auth', ['ipCookie'])
 
 
           # capture input from user, authenticate serverside
-          submitLogin: (params, opts={}) ->
+          submitLogin: (params, opts={}, httpopts={}) ->
             @initDfd()
-            $http.post(@apiUrl(opts.config) + @getConfig(opts.config).emailSignInPath, params)
+            $http.post(@apiUrl(opts.config) + @getConfig(opts.config).emailSignInPath, params, httpopts)
               .success((resp) =>
                 @setConfigName(opts.config)
                 authData = @getConfig(opts.config).handleLoginResponse(resp, @)


### PR DESCRIPTION
Hi,

I added an other argument to `submitLogin` to pass to `$http.post()`.
My use case is : trying to disable a loading bar when logging in (see https://github.com/chieffancypants/angular-loading-bar#ignoring-particular-xhr-requests )

Hope you like it.
cc @pfalconetti