### PR TITLE
Add Angular 1.5.3 support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": ">=1.4 <=1.5.2",
+    "angular": ">=1.4 <=1.5.3",
     "angular-cookie": "~4.1.0"
   }
 }


### PR DESCRIPTION
It would be nice to drop the ```<= 1.5.x``` dependency check.  Let me know your thoughts and if agree I will submit a new PR