### PR TITLE
Fix method getSavedConfig.

### DIFF
--- a/src/ng-token-auth.coffee
+++ b/src/ng-token-auth.coffee
@@ -809,7 +809,7 @@ angular.module('ng-token-auth', ['ipCookie'])
 
             if @hasLocalStorage()
               c ?= JSON.parse($window.localStorage.getItem(key))
-            else if @hasSessionStorage()
+            if @hasSessionStorage()
               c ?= JSON.parse($window.sessionStorage.getItem(key))
 
             c ?= ipCookie(key)


### PR DESCRIPTION
Fix the following method:

```
getSavedConfig: ->
            c   = undefined
            key = 'currentConfigName'

            if @hasLocalStorage()
              c ?= JSON.parse($window.localStorage.getItem(key))
            else if @hasSessionStorage()
              c ?= JSON.parse($window.sessionStorage.getItem(key))

            c ?= ipCookie(key)

            return c || defaultConfigName
```

When using multiple user types and sessionStorage, this method is returning always the first available config (which is incorrect if you are not using the first available config to login). The problem is that if localStorage is enabled (@hasLocalStorage() returns true) then the saved configuration will never be found in the sessionStorage due to the **else** clause. The issue would be resolved by removing the else clause.

I hope this helps.
By the way, the module works like a charm. Congratulations!

Best regards